### PR TITLE
graalvm native image support

### DIFF
--- a/src/main/java/org/mvnsearch/chatgpt/spring/config/ChatGPTAutoConfiguration.java
+++ b/src/main/java/org/mvnsearch/chatgpt/spring/config/ChatGPTAutoConfiguration.java
@@ -1,9 +1,14 @@
 package org.mvnsearch.chatgpt.spring.config;
 
+import org.mvnsearch.chatgpt.model.*;
+import org.mvnsearch.chatgpt.model.function.GPTFunction;
 import org.mvnsearch.chatgpt.model.function.GPTFunctionsStub;
+import org.mvnsearch.chatgpt.model.function.JsonSchemaFunction;
+import org.mvnsearch.chatgpt.model.function.Parameter;
 import org.mvnsearch.chatgpt.spring.http.OpenAIChatAPI;
 import org.mvnsearch.chatgpt.spring.service.ChatGPTService;
 import org.mvnsearch.chatgpt.spring.service.ChatGPTServiceImpl;
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +20,18 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+@RegisterReflectionForBinding({
+        ChatCompletionRequest.class,
+        ChatCompletionResponse.class,
+        ChatCompletionChoice.class,
+        ChatCompletionUsage.class,
+        Parameter.class,
+        GPTFunction.class,
+        GPTFunctionsStub.class,
+        ChatMessage.class,
+        FunctionCall.class,
+        JsonSchemaFunction.class
+})
 @AutoConfiguration
 public class ChatGPTAutoConfiguration {
 


### PR DESCRIPTION
hello Jacky! How're u doin'? I love this project! I noticed there are no hints for GraalVM native image creation yet. I started the work to introduce them here. Now, if someone goes to start.spring.io, adds `GraalVM Native Image support` and then adds your starter, they can turn some code that uses jsut your API into a GraalVM native image. they still need to register hints for _their_ functions, however. I'll see if i can simplify this situation in a new PR.